### PR TITLE
Added Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ already installed dependencies.
 
 ![Cargo-temp demo](t-rec.gif)
 
-Only \*nix OS are supported for now because a shell is ran while the project is being edited by the user.
-It would be nice to have this working on Windows.
-If you know how to achieve this, please open an issue to tell us (or a PR.)
-
 ## Install
 
 Requires Rust 1.51.

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,14 +149,6 @@ fn get_shell() -> String {
     {
         env::var("COMSPEC").unwrap_or_else(|_| "cmd".to_string())
     }
-
-    #[cfg(not(any(unix, windows)))]
-    {
-        compile_error!(
-            "Only *nix and Windows systems supported at the moment. \
-            Help would be appreciated =D"
-        )
-    }
 }
 
 fn parse_dependency(s: &str) -> (String, Option<String>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,10 +145,15 @@ fn get_shell() -> String {
         env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        env::var("COMSPEC").unwrap_or_else(|_| "cmd".to_string())
+    }
+
+    #[cfg(not(any(unix, windows)))]
     {
         compile_error!(
-            "Only unix systems supported at the moment. \
+            "Only *nix and Windows systems supported at the moment. \
             Help would be appreciated =D"
         )
     }


### PR DESCRIPTION
```
PS C:\Users\yoh\source\cargo-temp> cargo run
   Compiling cargo-temp v0.1.1 (C:\Users\yoh\source\cargo-temp)
    Finished dev [unoptimized + debuginfo] target(s) in 1.35s
     Running `target\debug\cargo-temp.exe`
     Created binary (application) package
Microsoft Windows [Version 10.0.21354.1]
(c) Microsoft Corporation. All rights reserved.

C:\Users\yoh\AppData\Local\cargo-temp\tmp-5nQsQO>dir
 Volume in drive C has no label.
 Volume Serial Number is 48B4-60B2

 Directory of C:\Users\yoh\AppData\Local\cargo-temp\tmp-5nQsQO

05/04/2021  04:14 PM    <DIR>          .
05/04/2021  04:14 PM    <DIR>          ..
05/04/2021  04:14 PM                 8 .gitignore
05/04/2021  04:14 PM               233 Cargo.toml
05/04/2021  04:14 PM    <DIR>          src
05/04/2021  04:14 PM                53 TO_DELETE
               3 File(s)            294 bytes
               3 Dir(s)  361,829,834,752 bytes free

C:\Users\yoh\AppData\Local\cargo-temp\tmp-5nQsQO>exit
PS C:\Users\yoh\source\cargo-temp>
```