### PR TITLE
Replace == with = in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ Create a new temporary project:
     `$ cargo-temp`
 * With multiple dependencies:
     `$ cargo-temp rand tokio`
-* When specifying a version (You can use the 
-  [cargo's comparison requirements][comparison])
-    * `$ cargo-temp anyhow=1.0`
-    * `$ cargo-temp tokyo=<1.6`
-    * `$ cargo-temp tokyo=>1.8`
-    * `$ cargo-temp anyhow==1.0.13`
+* When specifying a version:
+    `$ cargo-temp anyhow=1.0`
+    * Using the [cargo's comparison requirements][comparison]:
+        `$ cargo-temp anyhow==1.0.13`
 
 ### Repositories
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Create a new temporary project:
 
 * With multiple dependencies:
     `$ cargo-temp rand tokio`
+* When specifying a version
+     `$ cargo-temp anyhow=1.0`       
 
 * With a dependency that have an exact version:
     `$ cargo-temp anyhow=1.0.13`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Create a new temporary project:
 * With multiple dependencies:
     `$ cargo-temp rand tokio`
 
-* With a dependency that have a fixed version:
+* With a dependency that have an exact version:
     `$ cargo-temp anyhow=1.0.13`
 
 ### Repositories

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Create a new temporary project:
     `$ cargo-temp rand tokio`
 
 * With a dependency that have a fixed version:
-    `$ cargo-temp anyhow==1.0.13`
+    `$ cargo-temp anyhow=1.0.13`
 
 ### Repositories
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Create a new temporary project:
 
 * With no additional dependencies:
     `$ cargo-temp`
-
 * With multiple dependencies:
     `$ cargo-temp rand tokio`
-* When specifying a version
-     `$ cargo-temp anyhow=1.0`       
-
-* With a dependency that have an exact version:
-    `$ cargo-temp anyhow=1.0.13`
+* When specifying a version (You can use the 
+  [cargo's comparison requirements][comparison])
+    * `$ cargo-temp anyhow=1.0`
+    * `$ cargo-temp tokyo=<1.6`
+    * `$ cargo-temp tokyo=>1.8`
+    * `$ cargo-temp anyhow==1.0.13`
 
 ### Repositories
 
@@ -38,8 +38,8 @@ Examples:
 * SSH
     `$ cargo-temp anyhow=ssh://git@github.com/dtolnay/anyhow.git`
 
-This will add the repository on the default branch by default. You can choose
-another branch or a revision:
+This will add the repository on the last commit of the main branch by default. 
+You can choose another branch or a revision:
 
 * Branch
     `$ cargo-temp anyhow=https://github.com/dtolnay/anyhow.git#branch=master`
@@ -57,8 +57,8 @@ editor exits.
 
 The config file is located at `{CONFIG_DIR}/cargo-temp/config.toml`.
 When you run `cargo-temp` for the first time it will be created automatically.
-We use the [XDG system](https://docs.rs/xdg/2.2.0/xdg/) for both Linux and OSX
-and the [Know Folder system](https://docs.rs/dirs-2/3.0.1/dirs_2/) on Windows.
+We use the [XDG system][xdg] for both Linux and OSX
+and the [Known Folder system][knownfolder] on Windows.
 
 ### Temporary project directory
 
@@ -91,3 +91,7 @@ editor_args = [ "--wait", "--new-window" ]
 editor = "C:\\Program Files\\Microsoft VS Code\\Code.exe"
 editor_args = [ "--wait", "--new-window" ]
 ```
+
+[comparison]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#comparison-requirements
+[xdg]: https://docs.rs/xdg/2.2.0/xdg/
+[knownfolder]: https://docs.rs/dirs-2/3.0.1/dirs_2/

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Create a new temporary project:
 
 * With no additional dependencies:
     `$ cargo-temp`
+    
 * With multiple dependencies:
     `$ cargo-temp rand tokio`
+    
 * When specifying a version:
     `$ cargo-temp anyhow=1.0`
     * Using the [cargo's comparison requirements][comparison]:
@@ -36,14 +38,15 @@ Examples:
 * SSH
     `$ cargo-temp anyhow=ssh://git@github.com/dtolnay/anyhow.git`
 
-This will add the repository on the last commit of the main branch by default. 
-You can choose another branch or a revision:
+To choose a branch or a revision:
 
 * Branch
     `$ cargo-temp anyhow=https://github.com/dtolnay/anyhow.git#branch=master`
 
 * Revision
     `$ cargo-temp anyhow=https://github.com/dtolnay/anyhow.git#rev=7e0f77a38`
+
+Without a branch or a revision, cargo will use the default branch of the repository.
 
 ## Features
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ struct Cli {
     /// Dependencies to add to `Cargo.toml`.
     ///
     /// The default version used is `*` but this can be replaced using `=`.
-    /// E.g. `cargo-temp anyhow==1.0.13`
+    /// E.g. `cargo-temp anyhow=1.0.13`
     #[clap(parse(from_str = parse_dependency))]
     dependencies: Vec<Dependency>,
 
@@ -271,10 +271,10 @@ mod parse_dependency_tests {
     }
 
     #[test]
-    fn dependency_with_minor_version() {
+    fn dependency_with_compatible_version() {
         assert_eq!(
-            parse_dependency("anyhow==1.1.0"),
-            Dependency::CrateIo("anyhow".to_string(), Some("=1.1.0".to_string()))
+            parse_dependency("anyhow=^1.1.0"),
+            Dependency::CrateIo("anyhow".to_string(), Some("^1.1.0".to_string()))
         )
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,14 +271,6 @@ mod parse_dependency_tests {
     }
 
     #[test]
-    fn dependency_with_compatible_version() {
-        assert_eq!(
-            parse_dependency("anyhow=^1.1.0"),
-            Dependency::CrateIo("anyhow".to_string(), Some("^1.1.0".to_string()))
-        )
-    }
-
-    #[test]
     fn repository_with_http() {
         assert_eq!(
             parse_dependency("anyhow=https://github.com/dtolnay/anyhow.git"),


### PR DESCRIPTION
I found the documentation confusing because the extra `=`. `anyhow = "=1.1.0"` does seem to be valid in `Cargo.toml` but I don't think it is ever used because I don't see how it is different to `anyhow = "1.1.0"`.

I replaced the test with one using `^` as I've seen that used in `Cargo.toml`s before so it's probably more worth testing than `=`.

Hope this is helpful. Thanks for creating a great tool.