### PR TITLE
Append project name to the temporary directory if any

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,17 +259,6 @@ The available options are:
 
 If the argument doesn't match these options, the default is the latest edition.
 
-### Project name
-
-If you want to provide a specific project name, you can use the `--name` option:
-
-```
-cargo-temp --name my-awesome-project
-```
-
-The project will be renamed to match the provided project name if you decide to preserve it when
-exiting the shell.
-
 ### Generate
 
 Generate a temporary project from a template using [`cargo-generate`][cargo-generate]

--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ The available options are:
 
 If the argument doesn't match these options, the default is the latest edition.
 
+### Project name
+
+If you want to provide a specific project name, you can use the `--name` option:
+
+```
+cargo-temp --name project
+```
+
+This name will be used as the suffix of the temporary project directory, like `tmp-wXyZ-project`.
+If you decide to preserve the project, the directory will be renamed to match the project's name.
+
 ### Generate
 
 Generate a temporary project from a template using [`cargo-generate`][cargo-generate]

--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ The available options are:
 
 If the argument doesn't match these options, the default is the latest edition.
 
+### Project name
+
+If you want to provide a specific project name, you can use the `--name` option:
+
+```
+cargo-temp --name my-awesome-project
+```
+
+The project will be renamed to match the provided project name if you decide to preserve it when
+exiting the shell.
+
 ### Generate
 
 Generate a temporary project from a template using [`cargo-generate`][cargo-generate]

--- a/src/run.rs
+++ b/src/run.rs
@@ -55,19 +55,27 @@ pub fn generate_tmp_project(
 ) -> Result<TempDir> {
     let tmp_dir = {
         let mut builder = tempfile::Builder::new();
+        let mut suffix = String::new();
 
-        if cli.worktree_branch.is_some() {
-            builder.prefix("wk-");
+        let prefix = if cli.worktree_branch.is_some() {
+            "wk-"
         } else {
-            builder.prefix("tmp-");
-        }
+            "tmp-"
+        };
+
+        if let Some(name) = cli.project_name.as_deref() {
+            suffix = format!("-{}", name);
+        };
 
         if !temporary_project_dir.exists() {
             fs::create_dir_all(temporary_project_dir)
                 .context("cannot create temporary project's directory")?;
         }
 
-        builder.tempdir_in(temporary_project_dir)?
+        builder
+            .prefix(&prefix)
+            .suffix(&suffix)
+            .tempdir_in(temporary_project_dir)?
     };
 
     let project_name = cli.project_name.unwrap_or_else(|| {

--- a/src/run.rs
+++ b/src/run.rs
@@ -56,11 +56,16 @@ pub fn generate_tmp_project(
 ) -> Result<TempDir> {
     let tmp_dir = {
         let mut builder = tempfile::Builder::new();
+        let mut suffix = String::new();
 
-        if cli.worktree_branch.is_some() {
-            builder.prefix("wk-")
+        let prefix = if cli.worktree_branch.is_some() {
+            "wk-"
         } else {
-            builder.prefix("tmp-")
+            "tmp-"
+        };
+
+        if let Some(name) = cli.project_name.as_deref() {
+            suffix = format!("-{}", name);
         };
 
         if !temporary_project_dir.exists() {
@@ -68,7 +73,10 @@ pub fn generate_tmp_project(
                 .context("cannot create temporary project's directory")?;
         }
 
-        builder.tempdir_in(temporary_project_dir)?
+        builder
+            .prefix(&prefix)
+            .suffix(&suffix)
+            .tempdir_in(temporary_project_dir)?
     };
 
     let project_name = cli.project_name.unwrap_or_else(|| {

--- a/src/run.rs
+++ b/src/run.rs
@@ -39,6 +39,7 @@ pub fn execute(cli: Cli, config: Config) -> Result<()> {
         &delete_file,
         tmp_dir,
         cli.worktree_branch.flatten().as_deref(),
+        cli.project_name.as_deref(),
         &mut subprocesses,
     )?;
 
@@ -273,13 +274,21 @@ pub fn clean_up(
     delete_file: &Path,
     tmp_dir: TempDir,
     worktree_branch: Option<&str>,
+    project_name: Option<&str>,
     subprocesses: &mut [Child],
 ) -> Result<()> {
     if !delete_file.exists() {
-        log::info!(
-            "Project directory preserved at: {}",
-            tmp_dir.into_path().display()
-        );
+        let mut tmp_dir = tmp_dir.into_path();
+
+        if let Some(name) = project_name {
+            let new_path = tmp_dir.with_file_name(&name);
+
+            fs::rename(&tmp_dir, &new_path)?;
+
+            tmp_dir = new_path;
+        }
+
+        log::info!("Project directory preserved at: {}", tmp_dir.display());
     } else if worktree_branch.is_some() {
         let mut command = std::process::Command::new("git");
         command

--- a/src/run.rs
+++ b/src/run.rs
@@ -56,16 +56,11 @@ pub fn generate_tmp_project(
 ) -> Result<TempDir> {
     let tmp_dir = {
         let mut builder = tempfile::Builder::new();
-        let mut suffix = String::new();
 
-        let prefix = if cli.worktree_branch.is_some() {
-            "wk-"
+        if cli.worktree_branch.is_some() {
+            builder.prefix("wk-")
         } else {
-            "tmp-"
-        };
-
-        if let Some(name) = cli.project_name.as_deref() {
-            suffix = format!("-{}", name);
+            builder.prefix("tmp-")
         };
 
         if !temporary_project_dir.exists() {
@@ -73,10 +68,7 @@ pub fn generate_tmp_project(
                 .context("cannot create temporary project's directory")?;
         }
 
-        builder
-            .prefix(&prefix)
-            .suffix(&suffix)
-            .tempdir_in(temporary_project_dir)?
+        builder.tempdir_in(temporary_project_dir)?
     };
 
     let project_name = cli.project_name.unwrap_or_else(|| {


### PR DESCRIPTION
If the user provide a project name we:

- [x] Use the project name as the suffix of the temporary directory.
- [x] Replace the temporary project name by the project name when exiting the shell without `TO_DELETE` file.

Closes #62 