### PR TITLE
Print a welcome message when creating a new temporary project

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,6 @@ This message is enabled by default and can be disabled using the `welcome_messag
 welcome_message = false
 ```
 
-
 ### Temporary project directory
 
 The path where the temporary projects are created.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,18 @@ When you run `cargo-temp` for the first time it will be created automatically.
 We use the [XDG system][xdg] for both Linux and OSX
 and the [Known Folder system][knownfolder] on Windows.
 
+### Welcome message
+
+Each time you create a temporary project, a welcome message explain how to exit the temporary
+project and how to preserve it when exiting.
+
+This message is enabled by default and can be disabled using the `welcome_message` setting:
+
+```toml
+welcome_message = false
+```
+
+
 ### Temporary project directory
 
 The path where the temporary projects are created.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
+    pub welcome_message: bool,
     pub cargo_target_dir: Option<String>,
     pub editor: Option<String>,
     pub editor_args: Option<Vec<String>>,
@@ -34,6 +35,7 @@ impl Config {
             .join(env!("CARGO_PKG_NAME"));
 
         Ok(Self {
+            welcome_message: true,
             cargo_target_dir: None,
             editor: None,
             editor_args: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
+    #[serde(default = "is_true")]
     pub welcome_message: bool,
     #[serde(default)]
     pub cargo_target_dir: Option<String>,
@@ -23,6 +24,10 @@ pub struct Config {
     pub vcs: Option<String>,
     #[serde(default, rename = "subprocess", skip_serializing_if = "Vec::is_empty")]
     pub subprocesses: Vec<SubProcess>,
+}
+
+fn is_true() -> bool {
+    true
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
-    #[serde(default = "is_true")]
+    #[serde(default)]
     pub welcome_message: bool,
     #[serde(default)]
     pub cargo_target_dir: Option<String>,
@@ -24,10 +24,6 @@ pub struct Config {
     pub vcs: Option<String>,
     #[serde(default, rename = "subprocess", skip_serializing_if = "Vec::is_empty")]
     pub subprocesses: Vec<SubProcess>,
-}
-
-fn is_true() -> bool {
-    true
 }
 
 impl Config {

--- a/src/run.rs
+++ b/src/run.rs
@@ -32,8 +32,8 @@ pub fn execute(cli: Cli, config: Config) -> Result<()> {
 
     if config.welcome_message {
         println!(
-            "\nTo preserve the project when exiting the shell, don't forget to\
- delete the `TO_DELETE` file.\nTo exit the project, you can type \"exit\" or use `Ctrl+D`"
+            "\nTo preserve the project when exiting the shell, don't forget to delete the \
+            `TO_DELETE` file.\nTo exit the project, you can type \"exit\" or use `Ctrl+D`"
         );
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -28,10 +28,14 @@ pub fn execute(cli: Cli, config: Config) -> Result<()> {
 
     let mut subprocesses = start_subprocesses(&config, tmp_dir.path());
 
-    log::info!(
-        "Temporary project created at: {}",
-        &tmp_dir.path().display()
-    );
+    log::info!("Temporary project created at: {}", tmp_dir.path().display());
+
+    if config.welcome_message {
+        println!(
+            "\nTo preserve the project when exiting the shell, don't forget to\
+ delete the `TO_DELETE` file.\nTo exit the project, you can type \"exit\" or use `Ctrl+D`"
+        );
+    }
 
     let res = start_shell(&config, tmp_dir.path());
 


### PR DESCRIPTION
- [x] Add a `welcome_message` setting to the config file to enable or disable the welcome message
- [x] Print a welcome message when creating a new temporary project that explains how to exit and how to preserve the project when exiting. 

Closes #63