### PR TITLE
Move the project to a different location if the project is preserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,10 @@ editor_args = ["--wait", "--new-window"]
 # Specify the VCS you want to use within the project. Default is `git`.
 vcs = "pijul"
 
+# Specify the dir to move the project if you want to preserve it
+# in another path. Optional.
+preserve_dir = "/home/me/projects/"
+
 # Use a confirmation prompt before deleting a project
 prompt = true
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ editor_args = ["--wait", "--new-window"]
 vcs = "pijul"
 
 # Specify the path to the directory where you want to preserve a saved project. Optional (default is `temporary_project_dir`).
-preserve_dir = "/home/me/projects/"
+preserved_project_dir = "/home/me/projects/"
 
 # Use a confirmation prompt before deleting a project
 prompt = true

--- a/README.md
+++ b/README.md
@@ -443,8 +443,7 @@ editor_args = ["--wait", "--new-window"]
 # Specify the VCS you want to use within the project. Default is `git`.
 vcs = "pijul"
 
-# Specify the dir to move the project if you want to preserve it
-# in another path. Optional.
+# Specify the path to the directory where you want to preserve a saved project. Optional (default is `temporary_project_dir`).
 preserve_dir = "/home/me/projects/"
 
 # Use a confirmation prompt before deleting a project

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
     #[serde(default)]
     pub cargo_target_dir: Option<String>,
     #[serde(default)]
-    pub preserve_dir: Option<String>,
+    pub preserved_project_dir: Option<String>,
     #[serde(default)]
     pub prompt: bool,
     #[serde(default)]
@@ -45,7 +45,7 @@ impl Config {
         Ok(Self {
             welcome_message: true,
             cargo_target_dir: None,
-            preserve_dir: None,
+            preserved_project_dir: None,
             prompt: false,
             editor: None,
             editor_args: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,9 @@ pub struct Config {
     #[serde(default)]
     pub welcome_message: bool,
     #[serde(default)]
-    pub cargo_target_dir: Option<String>,
+    pub cargo_target_dir: Option<PathBuf>,
     #[serde(default)]
-    pub preserved_project_dir: Option<String>,
+    pub preserved_project_dir: Option<PathBuf>,
     #[serde(default)]
     pub prompt: bool,
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     #[serde(default)]
     pub cargo_target_dir: Option<String>,
     #[serde(default)]
+    pub preserve_dir: Option<String>,
+    #[serde(default)]
     pub prompt: bool,
     #[serde(default)]
     pub editor: Option<String>,
@@ -43,6 +45,7 @@ impl Config {
         Ok(Self {
             welcome_message: true,
             cargo_target_dir: None,
+            preserve_dir: None,
             prompt: false,
             editor: None,
             editor_args: None,

--- a/src/run.rs
+++ b/src/run.rs
@@ -339,7 +339,7 @@ pub fn clean_up(
 }
 
 // preserve dir by renaming to appropriate name if project_name is set
-// and moves the project dir to preserve_dir as defined by the user
+// and moves the project dir to preserved_project_dir as defined by the user
 // it returns the dir where the project is preserved
 pub fn preserve_dir(
     tmp_dir: TempDir,

--- a/src/run.rs
+++ b/src/run.rs
@@ -355,7 +355,7 @@ pub fn preserve_dir(
     if let Some(preserve_dir) = preserve_dir {
         let folder_to_move = final_tmp_dir
             .file_name()
-            .context("cannot find the projects directory name")?;
+            .context("cannot find the project's directory name")?;
         let mut preserve_dir = PathBuf::from(preserve_dir);
 
         if !preserve_dir.exists() {

--- a/src/run.rs
+++ b/src/run.rs
@@ -338,9 +338,6 @@ pub fn clean_up(
     Ok(())
 }
 
-// preserve dir by renaming to appropriate name if project_name is set
-// and moves the project dir to preserved_project_dir as defined by the user
-// it returns the dir where the project is preserved
 pub fn preserve_dir(
     tmp_dir: TempDir,
     project_name: Option<&str>,

--- a/src/run.rs
+++ b/src/run.rs
@@ -347,23 +347,24 @@ pub fn preserve_dir(
     preserved_project_dir: Option<&Path>,
 ) -> Result<PathBuf> {
     let tmp_dir = tmp_dir.into_path();
-    let mut final_dir = tmp_dir.clone();
 
-    if let Some(name) = project_name {
-        final_dir = tmp_dir.with_file_name(name);
-    }
-
-    if let Some(preserved_project_dir) = preserved_project_dir {
+    let mut final_dir = if let Some(preserved_project_dir) = preserved_project_dir {
         if !preserved_project_dir.exists() {
             fs::create_dir_all(preserved_project_dir)
                 .context("cannot create preserve project's directory")?;
         }
 
-        final_dir = preserved_project_dir.join(
-            final_dir
+        preserved_project_dir.join(
+            tmp_dir
                 .file_name()
                 .context("cannot create preserve project's directory")?,
-        );
+        )
+    } else {
+        tmp_dir.clone()
+    };
+
+    if let Some(name) = project_name {
+        final_dir = final_dir.with_file_name(name);
     }
 
     if final_dir != tmp_dir {


### PR DESCRIPTION
Related to https://github.com/yozhgoor/cargo-temp/issues/71, it adds a new optional config key to move the projects to another path when they are preserved.

I moved all the code related to the preservation of the directory to a new method so it can be called elsewhere if needed.